### PR TITLE
Revert " Create option for user defined report settings #309"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,10 +89,6 @@ class User
   property :last_email_report_at, ZonedTime
   property :email_reports, Boolean, :default => false
 
-  property :daily_reports, Boolean, :default => false
-  property :weekly_reports, Boolean, :default => false
-  property :monthly_reports, Boolean, :default => false
-
   has n, :notifications, :constraint => :destroy
 
   has n, :favorites, :child_key => :user_id, :constraint => :destroy

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -40,7 +40,7 @@
 		</div>
 
 		<div class='grid_5'>
-            <% if not Snorby::CONFIG[:user_reports_control] %>
+
 			<p>
 				<%= check_box_tag '[settings][daily]', 1, (Setting.daily ? Setting.find(:daily) : nil) %> <%= label_tag 'Daily Reports' %><br />
 				<i>(Send a report summarizing the captured traffic daily.)</i><br />
@@ -55,7 +55,6 @@
 				<%= check_box_tag '[settings][monthly]', 1, (Setting.monthly ? Setting.find(:monthly) : nil) %> <%= label_tag 'Monthly Reports' %><br />
 				<i>(Send a report summarizing the captured traffic monthly)</i><br />
 			</p>
-        <% end %>
 
 			<p>
 				<%= check_box_tag '[settings][lookups]', 1, (Setting.lookups ? Setting.find(:lookups) : nil) %> <%= label_tag 'Address Lookups' %><br />

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -86,27 +86,8 @@
 
 					<p>
 						<%= f.check_box :admin %> <%= f.label "Administrator" %>
-                        <br />
 						<em>(should this user have administrative rights?)</em>
 					</p>
-                <% end %>
-
-                <% if Snorby::CONFIG[:user_reports_control] %>
-                    <p>
-                        <%= f.check_box :daily_reports %> <%= f.label 'Daily Reports' %>
-                        <br />
-                        <em>(Send a report summarizing the captured traffic daily)</em>
-                    </p>
-                    <p>
-                        <%= f.check_box :weekly_reports %> <%= f.label 'Weekly Reports' %>
-                        <br />
-                        <em>(Send a report summarizing the captured traffic weekly)</em>
-                    </p>
-                    <p>
-                        <%= f.check_box :monthly_reports %> <%= f.label 'Monthly Reports' %>
-                        <br />
-                        <em>(Send a report summarizing the captured traffic monthly)</em>
-                    </p>
 
 				<% end %>
 

--- a/config/snorby_config.yml.example
+++ b/config/snorby_config.yml.example
@@ -23,9 +23,6 @@ production:
   timezone_search: true
   # uncomment to set time zone to time zone of box from /usr/share/zoneinfo, e.g. "America/Cancun"
   # time_zone: 'UTC'
-  # user_reports_control: true => give control of receiving reports to individual users
-  # user_reports_control: false (previous default)=> configure reports globally
-  user_reports_control: false
 
 #
 # Only Use For Development

--- a/lib/snorby/jobs/sensor_cache_job.rb
+++ b/lib/snorby/jobs/sensor_cache_job.rb
@@ -144,7 +144,7 @@ module Snorby
                 now = current_time.to_date + 0.second
                 yesterday = current_time.yesterday.to_date + 0.second
 
-                if (Snorby::CONFIG[:user_reports_control] and user.daily_reports) or ((not       Snorby::CONFIG[:user_reports_control]) and Setting.daily?)
+                if Setting.daily?
                   last_report_to_date = if user.last_daily_report_at.present?
                                           user.last_daily_report_at.in_time_zone(user.timezone).to_date + 0.second
                                         else
@@ -168,7 +168,7 @@ module Snorby
 
 
                 # Weekly
-                if (Snorby::CONFIG[:user_reports_control] and user.weekly_reports) or ((not      Snorby::CONFIG[:user_reports_control]) and Setting.weekly?)
+                if Setting.weekly?
                   current_week = current_time.strftime('%Y%W').to_i
 
                   last_weekly_to_date = if user.last_weekly_report_at.present?
@@ -188,7 +188,7 @@ module Snorby
                 end
 
                 # Monthly
-                if (Snorby::CONFIG[:user_reports_control] and user.monthly_reports) or ((not     Snorby::CONFIG[:user_reports_control]) and Setting.monthly?)
+                if Setting.monthly?
                   current_month = current_time.strftime('%Y%m').to_i
 
                   last_monthly_to_date = if user.last_monthly_report_at.present?


### PR DESCRIPTION
Reverts Flashdown/snorby#6

I believe general mail notification reciepients should not depend on users instead there should be a setting on the Settings page to configure it independent. 